### PR TITLE
Should be possible to toggle multiple feature flags via WordPress admin 

### DIFF
--- a/feature-flags/assets/js/feature-flags.js
+++ b/feature-flags/assets/js/feature-flags.js
@@ -3,7 +3,7 @@
 /* global jQuery, ffwp */
 jQuery( document ).ready( function( $ ) {
 
-	$( '#flagActivateButton' ).on( 'click', function( e ) {
+	$( '[data-action="toggleFeatureFlag"]' ).on( 'click', function( e ) {
 
 		var $button    = e.target;
 		var featureKey = $button.parentElement.parentElement.querySelector( 'pre' ).innerHTML;

--- a/feature-flags/includes/admin/settings-page.php
+++ b/feature-flags/includes/admin/settings-page.php
@@ -60,12 +60,12 @@ add_action( 'admin_menu', function () {
 
 									if ( $enabled ) {
 										submit_button( 'Disable', 'small', 'featureFlags-disable', false, [
-											'id'          => 'flagActivateButton',
+											'data-action'          => 'toggleFeatureFlag',
 											'data-status' => 'enabled',
 										] );
 									} else {
 										submit_button( 'Enable', 'small', 'featureFlags-enable', false, [
-											'id'          => 'flagActivateButton',
+											'data-action'          => 'toggleFeatureFlag',
 											'data-status' => 'disabled',
 										] );
 									}


### PR DESCRIPTION
The jQuery click function was previously only bound to the toggle button for the first feature flag in the list, because an ID selector was used.