### PR TITLE
ACF Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Example:
 https://www.example.com?group=battery-horse-staple
 ```
 
+## Advanced Custom Fields (ACF) Support
+
+ACF field groups can also be set to show or hide based on feature flags.
+
+In the 'Location' section of a field group, 'Feature flags' will be available as an option. This allows you to show a field group depending on whether a feature flag are enabled or not. This can be combined with the and/or rules to display a field group depending on the status of multiple feature flags.
+
 ## Shortcodes
 
 This plugin adds a number of utility shortcodes to help to debug the use of Flagpole flags.

--- a/flagpole.php
+++ b/flagpole.php
@@ -100,6 +100,11 @@ require plugin_dir_path( __FILE__ ) . 'includes/admin/settings-page.php';
 require plugin_dir_path( __FILE__ ) . 'includes/api/api.general.php';
 require plugin_dir_path( __FILE__ ) . 'includes/api/api.shortcode.php';
 
+if ( class_exists( 'ACF' ) ) {
+	$acf_path = plugin_dir_path( __FILE__ ) . 'includes/acf/class-acf-filter.php';
+	include_once $acf_path;
+}
+
 /**
  * AJAX Action toggling features from the WP admin area.
  */
@@ -176,8 +181,12 @@ function flagpole_create_group() {
 	$validation = array_filter( $validation );
 
 	if ( $validation ) {
-		$result = Flagpole::init()->create_group( $validation['group-key'], $validation['group-name'],
-			$validation['group-desc'], $validation['group-private'] );
+		$result = Flagpole::init()->create_group(
+			$validation['group-key'],
+			$validation['group-name'],
+			$validation['group-desc'],
+			$validation['group-private']
+		);
 
 		flagpole_operation_redirect( $result );
 	}
@@ -338,3 +347,17 @@ function flagpole_operation_redirect( $error_code = false, $redirect = true ) {
 add_shortcode( 'debugFlagpole_flags', 'flagpole_shortcode_debug_flags' );
 add_shortcode( 'debugFlagpole_groups', 'flagpole_shortcode_debug_groups' );
 add_shortcode( 'debugFlagpole_db', 'flagpole_shortcode_debug_db' );
+
+// Check ACF exists before registering our filter.
+if ( class_exists( 'ACF' ) ) {
+	add_action( 'acf/init', __NAMESPACE__ . '\\flagpole_acf_location_type' );
+}
+
+/**
+ * Register our ACF feature flag location filter.
+ *
+ * @return void
+ */
+function flagpole_acf_location_type() {
+	acf_register_location_type( 'Flagpole\ACF_Filter' );
+}

--- a/includes/acf/class-acf-filter.php
+++ b/includes/acf/class-acf-filter.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Class to add feature flags defined with Flagpole as a filter option in ACF.
+ * Documentation for this functionality available here: https://www.advancedcustomfields.com/resources/custom-location-rules/
+ *
+ * @package Peake\Plugins
+ */
+
+namespace Flagpole;
+
+use ACF_Location;
+use Flagpole\Flagpole;
+
+/**
+ * Class ACF_Filter
+ *
+ * @package FeatureFlags
+ */
+class ACF_Filter extends ACF_Location {
+	// Type hints must match the original source exactly, so PHPCS checks have been disabled but docblocks are accurate.
+	// phpcs:disable NeutronStandard.Functions.TypeHint.NoArgumentType
+	// phpcs:disable NeutronStandard.Functions.TypeHint.NoReturnType
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+	/**
+	 * Sets the base values for the location filter.
+	 *
+	 * @return void
+	 */
+	public function initialize() {
+		$this->name     = 'feature-flags';
+		$this->label    = __( 'Feature flags', 'flagpole' );
+		$this->category = 'forms';
+	}
+
+	/**
+	 * Gets the list of feature flags as an ID => printable name pair.
+	 *
+	 * @param array $rule Information on the current rule (value, parameter, operator etc.).
+	 * @return array List of all flag IDs and names.
+	 */
+	public function get_values( $rule ) {
+		$flagpole_flags  = Flagpole::init()->get_flags();
+		$flagpole_values = array();
+
+		foreach ( $flagpole_flags as $flagpole_flag ) {
+			$flagpole_values[ $flagpole_flag->key ] = $flagpole_flag->name;
+		}
+
+		return $flagpole_values;
+	}
+
+	/**
+	 * Returns an array of operators.
+	 *
+	 * @param  array $rule A location rule.
+	 * @return array
+	 */
+	public static function get_operators( $rule ) {
+		return array(
+			'==' => __( 'is enabled', 'flagpole' ),
+			'!=' => __( 'is not enabled', 'flagpole' ),
+		);
+	}
+
+	/**
+	 * Returns true or false depending on whether or not the feature flag is enabled and whether our operator is '==' or '!='.
+	 *
+	 * @param array $rule Parameter info, including the operator and feature flag ID value.
+	 * @param array $screen Current page info (post type, ID, language).
+	 * @param array $field_group Field group info (field group name, rules, position etc.).
+	 * @return boolean Whether our parameters have been met.
+	 */
+	public function match( $rule, $screen, $field_group ) {
+		if ( '==' === $rule['operator'] ) {
+			return flagpole_flag_enabled( $rule['value'] );
+		}
+
+		if ( '=!' === $rule['operator'] ) {
+			return ! flagpole_flag_enabled( $rule['value'] );
+		}
+
+		return false;
+	}
+
+	// phpcs:enable NeutronStandard.Functions.TypeHint.NoArgumentType
+	// phpcs:enable NeutronStandard.Functions.TypeHint.NoReturnType
+	// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+}


### PR DESCRIPTION
Adds an ACF filter for Flagpole flags

![Screenshot 2021-08-02 at 14 50 13](https://user-images.githubusercontent.com/53259768/127872319-11fbac3f-aedf-4d0b-abee-a05e8f551a75.png)

Allows users to show or hide ACF field groups based on a feature flag, or combination of multiple flags.